### PR TITLE
Fix credit cards display

### DIFF
--- a/lib/providers/finance_provider.dart
+++ b/lib/providers/finance_provider.dart
@@ -17,6 +17,8 @@ class FinanceProvider extends ChangeNotifier {
   };
 
   List<Account> get accounts => _accounts;
+  List<Account> get creditAccounts =>
+      _accounts.where((a) => a.accountType == AccountType.credit).toList();
   List<Transaction> get transactions => _transactions;
   List<CreditCard> get creditCards => _creditCards;
   Map<String, double> get totalBalances => _totalBalances;

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -200,6 +200,9 @@ class _DashboardScreenState extends State<DashboardScreen> {
   }
 
   Widget _buildCreditCardsList(FinanceProvider provider) {
+    final creditCards = provider.creditCards;
+    final creditAccounts = provider.creditAccounts;
+
     return Card(
       elevation: 4,
       child: Padding(
@@ -212,7 +215,12 @@ class _DashboardScreenState extends State<DashboardScreen> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
-            ...provider.creditCards.map((card) => _buildCreditCardTile(card)),
+            if (creditCards.isEmpty && creditAccounts.isEmpty)
+              const Text('No hay tarjetas disponibles')
+            else ...[
+              ...creditCards.map((card) => _buildCreditCardTile(card)),
+              ...creditAccounts.map((account) => _buildAccountCardAsCredit(account)),
+            ],
           ],
         ),
       ),
@@ -255,6 +263,54 @@ class _DashboardScreenState extends State<DashboardScreen> {
           ),
           Text(
             'Disponible: ${currencyFormat.format(card.availableCredit)}',
+            style: const TextStyle(fontSize: 12, color: Colors.grey),
+          ),
+        ],
+      ),
+      isThreeLine: true,
+    );
+  }
+
+  Widget _buildAccountCardAsCredit(Account account) {
+    final limit = account.creditLimit ?? 0;
+    final used = account.balance.abs();
+    final available = limit - used;
+    final usagePercent = limit > 0 ? (used / limit) * 100 : 0.0;
+
+    return ListTile(
+      leading: CircleAvatar(
+        backgroundColor: _getBankColor(account.bankType),
+        child: const Icon(Icons.credit_card, color: Colors.white),
+      ),
+      title: Text(account.name),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Límite: ${currencyFormat.format(limit)}'),
+          const SizedBox(height: 4),
+          LinearProgressIndicator(
+            value: usagePercent / 100,
+            backgroundColor: Colors.grey[300],
+            color: usagePercent > 80 ? Colors.red : Colors.blue,
+          ),
+          const SizedBox(height: 2),
+          Text('${usagePercent.toStringAsFixed(1)}% utilizado'),
+        ],
+      ),
+      trailing: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        crossAxisAlignment: CrossAxisAlignment.end,
+        children: [
+          Text(
+            currencyFormat.format(account.balance),
+            style: const TextStyle(
+              fontSize: 14,
+              fontWeight: FontWeight.bold,
+              color: Colors.red,
+            ),
+          ),
+          Text(
+            'Disponible: ${currencyFormat.format(available)}',
             style: const TextStyle(fontSize: 12, color: Colors.grey),
           ),
         ],

--- a/lib/screens/modern_dashboard_screen.dart
+++ b/lib/screens/modern_dashboard_screen.dart
@@ -422,6 +422,9 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
   }
 
   Widget _buildCreditCardsSection(FinanceProvider provider) {
+    final creditCards = provider.creditCards;
+    final creditAccounts = provider.creditAccounts;
+
     return Card(
       child: Padding(
         padding: const EdgeInsets.all(16),
@@ -433,10 +436,12 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 8),
-            if (provider.creditCards.isEmpty)
+            if (creditCards.isEmpty && creditAccounts.isEmpty)
               const Text('No hay tarjetas disponibles')
-            else
-              ...provider.creditCards.map((card) => _buildCreditCardItem(card)),
+            else ...[
+              ...creditCards.map((card) => _buildCreditCardItem(card)),
+              ...creditAccounts.map((acc) => _buildCreditAccountItem(acc)),
+            ],
           ],
         ),
       ),
@@ -468,6 +473,38 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
       ),
       trailing: Text(
         currencyFormat.format(card.currentBalance),
+        style: const TextStyle(fontWeight: FontWeight.bold),
+      ),
+    );
+  }
+
+  Widget _buildCreditAccountItem(Account account) {
+    final limit = account.creditLimit ?? 0;
+    final used = account.balance.abs();
+    final utilizationPercent = limit > 0 ? used / limit * 100 : 0.0;
+
+    return ListTile(
+      contentPadding: EdgeInsets.zero,
+      leading: CircleAvatar(
+        backgroundColor: _getBankColor(account.bankType),
+        child: const Icon(Icons.credit_card, color: Colors.white),
+      ),
+      title: Text(account.name),
+      subtitle: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Text('Límite: ${currencyFormat.format(limit)}'),
+          LinearProgressIndicator(
+            value: utilizationPercent / 100,
+            backgroundColor: Colors.grey[300],
+            valueColor: AlwaysStoppedAnimation<Color>(
+              utilizationPercent > 80 ? Colors.red : AppTheme.primaryColor,
+            ),
+          ),
+        ],
+      ),
+      trailing: Text(
+        currencyFormat.format(account.balance),
         style: const TextStyle(fontWeight: FontWeight.bold),
       ),
     );


### PR DESCRIPTION
## Summary
- recognize credit account entries as credit cards
- display credit accounts along with credit cards on dashboards

## Testing
- `dart format lib test` *(fails: command not found)*
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687985e66e9483229a8a85c3d576add8