### PR TITLE
Add RESICO deductible expense search feature

### DIFF
--- a/lib/data/resico_deductibles.dart
+++ b/lib/data/resico_deductibles.dart
@@ -1,0 +1,68 @@
+const List<Map<String, dynamic>> deductibleExpenses = [
+  {
+    'name': 'Comida de negocio',
+    'keywords': ['comida', 'restaurante', 'alimentos'],
+    'deductible': true,
+    'detail':
+        'Deducible cuando sea con fines de negocio y cuentes con CFDI de restaurante con uso G03.'
+  },
+  {
+    'name': 'Compras personales de supermercado',
+    'keywords': ['supermercado', 'compras para casa', 'despensa'],
+    'deductible': false,
+    'detail':
+        'Gastos familiares o personales no se consideran acreditables para RESICO.'
+  },
+  {
+    'name': 'Gasolina para actividades',
+    'keywords': ['gasolina', 'combustible'],
+    'deductible': true,
+    'detail':
+        'El combustible utilizado para el negocio es deducible con CFDI y forma de pago registrada.'
+  },
+  {
+    'name': 'Ropa personal',
+    'keywords': ['ropa', 'zapatos'],
+    'deductible': false,
+    'detail': 'La ropa de uso personal no es un gasto acreditable.'
+  },
+  {
+    'name': 'Hospedaje y vi\u00e1ticos de trabajo',
+    'keywords': ['hospedaje', 'vi\u00e1ticos', 'hotel'],
+    'deductible': true,
+    'detail':
+        'Siempre que el viaje sea de negocios y cuentes con CFDI correcto.'
+  },
+  {
+    'name': 'Equipo de c\u00f3mputo',
+    'keywords': ['laptop', 'computadora', 'equipo de c\u00f3mputo'],
+    'deductible': true,
+    'detail':
+        'Computadoras y accesorios utilizados en tu actividad econ\u00f3mica con CFDI I04.'
+  },
+  {
+    'name': 'Multas y recargos',
+    'keywords': ['multas', 'recargos'],
+    'deductible': false,
+    'detail': 'Pagos de sanciones o recargos no son deducibles.'
+  },
+  {
+    'name': 'Publicidad y marketing',
+    'keywords': ['publicidad', 'marketing', 'anuncios'],
+    'deductible': true,
+    'detail': 'Gastos de promoci\u00f3n con factura a tu nombre.'
+  },
+  {
+    'name': 'Servicios de comunicaci\u00f3n',
+    'keywords': ['internet', 'celular', 'telefon\u00eda'],
+    'deductible': true,
+    'detail':
+        'Planes de telefon\u00eda e internet utilizados para el negocio con CFDI I06.'
+  },
+  {
+    'name': 'Entretenimiento personal',
+    'keywords': ['cine', 'ocio', 'entretenimiento'],
+    'deductible': false,
+    'detail': 'Diversi\u00f3n personal no es acreditable ante el SAT.'
+  },
+];

--- a/lib/screens/cfdi_guide_screen.dart
+++ b/lib/screens/cfdi_guide_screen.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'deductible_search_screen.dart';
 
 class CFDIGuideScreen extends StatelessWidget {
   const CFDIGuideScreen({super.key});
@@ -13,6 +14,19 @@ class CFDIGuideScreen extends StatelessWidget {
             expandedHeight: 200,
             floating: false,
             pinned: true,
+            actions: [
+              IconButton(
+                icon: const Icon(Icons.search),
+                onPressed: () {
+                  Navigator.push(
+                    context,
+                    MaterialPageRoute(
+                      builder: (context) => const DeductibleSearchScreen(),
+                    ),
+                  );
+                },
+              ),
+            ],
             flexibleSpace: FlexibleSpaceBar(
               title: const Text(
                 'Guía de CFDI para RESICO',

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -8,6 +8,7 @@ import 'accounts_screen.dart';
 import 'transactions_screen.dart';
 import 'compatible_transaction_screen.dart';
 import 'cfdi_guide_screen.dart';
+import 'deductible_search_screen.dart';
 
 class DashboardScreen extends StatefulWidget {
   const DashboardScreen({super.key});
@@ -374,6 +375,18 @@ class _DashboardScreenState extends State<DashboardScreen> {
                       context,
                       MaterialPageRoute(
                         builder: (context) => const CFDIGuideScreen(),
+                      ),
+                    );
+                  },
+                ),
+                _buildActionButton(
+                  icon: Icons.search,
+                  label: 'Buscador IVA',
+                  onTap: () {
+                    Navigator.push(
+                      context,
+                      MaterialPageRoute(
+                        builder: (context) => const DeductibleSearchScreen(),
                       ),
                     );
                   },

--- a/lib/screens/deductible_search_screen.dart
+++ b/lib/screens/deductible_search_screen.dart
@@ -1,0 +1,63 @@
+import 'package:flutter/material.dart';
+import '../data/resico_deductibles.dart';
+
+class DeductibleSearchScreen extends StatefulWidget {
+  const DeductibleSearchScreen({super.key});
+
+  @override
+  State<DeductibleSearchScreen> createState() => _DeductibleSearchScreenState();
+}
+
+class _DeductibleSearchScreenState extends State<DeductibleSearchScreen> {
+  String query = '';
+
+  @override
+  Widget build(BuildContext context) {
+    final results = deductibleExpenses.where((expense) {
+      final keywords = expense['keywords'] as List<String>;
+      return query.isEmpty ||
+          keywords.any((k) => k.toLowerCase().contains(query.toLowerCase()));
+    }).toList();
+
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Buscar gastos acreditables'),
+      ),
+      body: Column(
+        children: [
+          Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: TextField(
+              decoration: const InputDecoration(
+                labelText: 'Ingresa un gasto (ej. comida)',
+                prefixIcon: Icon(Icons.search),
+                border: OutlineInputBorder(),
+              ),
+              onChanged: (value) {
+                setState(() {
+                  query = value;
+                });
+              },
+            ),
+          ),
+          Expanded(
+            child: ListView.builder(
+              itemCount: results.length,
+              itemBuilder: (context, index) {
+                final expense = results[index];
+                return ListTile(
+                  leading: Icon(
+                    expense['deductible'] ? Icons.check_circle : Icons.cancel,
+                    color: expense['deductible'] ? Colors.green : Colors.redAccent,
+                  ),
+                  title: Text(expense['name'] as String),
+                  subtitle: Text(expense['detail'] as String),
+                );
+              },
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- add `resico_deductibles.dart` with sample deductible data
- create `DeductibleSearchScreen` with a search box to look up expenses
- link new screen from CFDI guide and dashboard quick actions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687987e351308322b38d3181f59cc615