### PR TITLE
Add CFDI Guide icon to dashboard app bar

### DIFF
--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -34,6 +34,20 @@ class _DashboardScreenState extends State<DashboardScreen> {
       appBar: AppBar(
         title: const Text('Mis Finanzas'),
         backgroundColor: Theme.of(context).colorScheme.inversePrimary,
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.help_outline),
+            tooltip: 'Guía CFDI',
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(
+                  builder: (context) => const CFDIGuideScreen(),
+                ),
+              );
+            },
+          ),
+        ],
       ),
       body: Consumer<FinanceProvider>(
         builder: (context, provider, child) {


### PR DESCRIPTION
## Summary
- add an AppBar action in `dashboard_screen` that navigates to `CFDIGuideScreen`

## Testing
- `dart --version` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6879895d91748322b70d42bcd00ed94a