### PR TITLE
Improve CFDI guide with more expenses

### DIFF
--- a/lib/data/resico_deductibles.dart
+++ b/lib/data/resico_deductibles.dart
@@ -1,8 +1,11 @@
+import 'package:flutter/material.dart';
+
 const List<Map<String, dynamic>> deductibleExpenses = [
   {
     'name': 'Comida de negocio',
     'keywords': ['comida', 'restaurante', 'alimentos'],
     'deductible': true,
+    'icon': Icons.restaurant,
     'detail':
         'Deducible cuando sea con fines de negocio y cuentes con CFDI de restaurante con uso G03.'
   },
@@ -10,6 +13,7 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Compras personales de supermercado',
     'keywords': ['supermercado', 'compras para casa', 'despensa'],
     'deductible': false,
+    'icon': Icons.shopping_cart,
     'detail':
         'Gastos familiares o personales no se consideran acreditables para RESICO.'
   },
@@ -17,6 +21,7 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Gasolina para actividades',
     'keywords': ['gasolina', 'combustible'],
     'deductible': true,
+    'icon': Icons.local_gas_station,
     'detail':
         'El combustible utilizado para el negocio es deducible con CFDI y forma de pago registrada.'
   },
@@ -24,12 +29,14 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Ropa personal',
     'keywords': ['ropa', 'zapatos'],
     'deductible': false,
+    'icon': Icons.checkroom,
     'detail': 'La ropa de uso personal no es un gasto acreditable.'
   },
   {
     'name': 'Hospedaje y vi\u00e1ticos de trabajo',
     'keywords': ['hospedaje', 'vi\u00e1ticos', 'hotel'],
     'deductible': true,
+    'icon': Icons.hotel,
     'detail':
         'Siempre que el viaje sea de negocios relacionado con consultor\u00eda en computaci\u00f3n y cuentes con CFDI correcto.'
   },
@@ -37,6 +44,7 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Equipo de c\u00f3mputo',
     'keywords': ['laptop', 'computadora', 'equipo de c\u00f3mputo'],
     'deductible': true,
+    'icon': Icons.computer,
     'detail':
         'Computadoras y accesorios utilizados en tu actividad econ\u00f3mica con CFDI I04.'
   },
@@ -44,6 +52,7 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Software y licencias',
     'keywords': ['software', 'licencias', 'suscripciones', 'programas'],
     'deductible': true,
+    'icon': Icons.developer_mode,
     'detail':
         'Herramientas de software y licencias necesarias para la consultor\u00eda en computaci\u00f3n con CFDI I04 o I08.'
   },
@@ -51,18 +60,21 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Multas y recargos',
     'keywords': ['multas', 'recargos'],
     'deductible': false,
+    'icon': Icons.gavel,
     'detail': 'Pagos de sanciones o recargos no son deducibles.'
   },
   {
     'name': 'Publicidad y marketing',
     'keywords': ['publicidad', 'marketing', 'anuncios'],
     'deductible': true,
+    'icon': Icons.campaign,
     'detail': 'Gastos de promoci\u00f3n con factura a tu nombre.'
   },
   {
     'name': 'Servicios de comunicaci\u00f3n',
     'keywords': ['internet', 'celular', 'telefon\u00eda'],
     'deductible': true,
+    'icon': Icons.phone,
     'detail':
         'Planes de telefon\u00eda e internet utilizados para consultor\u00eda en computaci\u00f3n con CFDI I06.'
   },
@@ -70,12 +82,14 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Entretenimiento personal',
     'keywords': ['cine', 'ocio', 'entretenimiento'],
     'deductible': false,
+    'icon': Icons.movie,
     'detail': 'Diversi\u00f3n personal no es acreditable ante el SAT.'
   },
   {
     'name': 'Sueldos y prestaciones a empleados',
     'keywords': ['sueldos', 'salarios', 'n\u00f3mina', 'prestaciones'],
     'deductible': false,
+    'icon': Icons.people,
     'detail':
         'Los pagos de n\u00f3mina y prestaciones sociales no generan IVA acreditable, aunque son deducibles de ISR si se cumplen los requisitos fiscales.'
   },
@@ -83,7 +97,106 @@ const List<Map<String, dynamic>> deductibleExpenses = [
     'name': 'Prestaci\u00f3n de servicios a terceros',
     'keywords': ['servicios', 'honorarios', 'prestaci\u00f3n de servicios'],
     'deductible': true,
+    'icon': Icons.handshake,
     'detail':
         'Los servicios contratados para tu actividad (consultor\u00eda, mantenimiento, etc.) generan IVA acreditable siempre que cuentes con CFDI y se relacionen con el negocio.'
+  },
+  {
+    'name': 'Transporte p\u00fablico por trabajo',
+    'keywords': ['transporte', 'bus', 'taxi'],
+    'deductible': true,
+    'icon': Icons.directions_bus,
+    'detail': 'Gastos de transporte cuando son necesarios para tu actividad y cuentes con CFDI.'
+  },
+  {
+    'name': 'Arrendamiento de oficina',
+    'keywords': ['renta', 'oficina'],
+    'deductible': true,
+    'icon': Icons.business,
+    'detail': 'La renta de un espacio destinado a tu actividad es acreditable con CFDI.'
+  },
+  {
+    'name': 'Mantenimiento de oficina',
+    'keywords': ['mantenimiento', 'reparaciones'],
+    'deductible': true,
+    'icon': Icons.build,
+    'detail': 'Reparaciones y mantenimiento del lugar de trabajo con factura son acreditables.'
+  },
+  {
+    'name': 'Material de oficina',
+    'keywords': ['papeler\u00eda', 'oficina'],
+    'deductible': true,
+    'icon': Icons.receipt,
+    'detail': 'Art\u00edculos de papeler\u00eda y materiales utilizados en el negocio.'
+  },
+  {
+    'name': 'Servicios de limpieza',
+    'keywords': ['limpieza', 'aseo'],
+    'deductible': true,
+    'icon': Icons.cleaning_services,
+    'detail': 'Gastos de limpieza para el \u00e1rea de trabajo con CFDI.'
+  },
+  {
+    'name': 'Seguros de responsabilidad',
+    'keywords': ['seguros', 'responsabilidad'],
+    'deductible': true,
+    'icon': Icons.verified_user,
+    'detail': 'P\u00f3lizas relacionadas con la actividad pueden acreditarse con CFDI.'
+  },
+  {
+    'name': 'Cursos y capacitaci\u00f3n',
+    'keywords': ['cursos', 'capacitacion', 'formaci\u00f3n'],
+    'deductible': true,
+    'icon': Icons.school,
+    'detail': 'Formaci\u00f3n y actualizaci\u00f3n profesional relacionada con tu actividad.'
+  },
+  {
+    'name': 'Suscripciones profesionales',
+    'keywords': ['suscripciones', 'revistas', 'software'],
+    'deductible': true,
+    'icon': Icons.subscriptions,
+    'detail': 'Suscripciones de uso profesional con CFDI v\u00e1lido.'
+  },
+  {
+    'name': 'Honorarios contables',
+    'keywords': ['contabilidad', 'impuestos'],
+    'deductible': true,
+    'icon': Icons.calculate,
+    'detail': 'Servicios de contabilidad y asesor\u00eda fiscal con CFDI I01.'
+  },
+  {
+    'name': 'Mobiliario de oficina',
+    'keywords': ['muebles', 'escritorio'],
+    'deductible': true,
+    'icon': Icons.chair,
+    'detail': 'Muebles y equipo menor utilizados en el \u00e1rea de trabajo con CFDI I04.'
+  },
+  {
+    'name': 'Pagos de luz y agua',
+    'keywords': ['electricidad', 'agua'],
+    'deductible': true,
+    'icon': Icons.lightbulb,
+    'detail': 'Servicios b\u00e1sicos del lugar de trabajo con comprobante fiscal.'
+  },
+  {
+    'name': 'Herramientas y equipo',
+    'keywords': ['herramientas', 'equipo menor'],
+    'deductible': true,
+    'icon': Icons.construction,
+    'detail': 'Herramientas necesarias para la actividad econ\u00f3mica con CFDI.'
+  },
+  {
+    'name': 'Mensajer\u00eda y paqueter\u00eda',
+    'keywords': ['env\u00edo', 'paqueter\u00eda'],
+    'deductible': true,
+    'icon': Icons.local_shipping,
+    'detail': 'Costos de env\u00edo de documentos o mercanc\u00edas relacionados al negocio.'
+  },
+  {
+    'name': 'Regalos a clientes',
+    'keywords': ['regalos', 'clientes'],
+    'deductible': false,
+    'icon': Icons.card_giftcard,
+    'detail': 'Obsequios ocasionales que no cumplen requisitos para deducir IVA.'
   },
 ];

--- a/lib/screens/cfdi_guide_screen.dart
+++ b/lib/screens/cfdi_guide_screen.dart
@@ -46,33 +46,43 @@ class _CFDIGuideScreenState extends State<CFDIGuideScreen> {
   Widget build(BuildContext context) {
     final results = _results;
 
+    final List<Widget> children = [
+      _buildSearchField(),
+      _buildFilterChips(),
+      Padding(
+        padding: const EdgeInsets.fromLTRB(16, 8, 16, 0),
+        child: Text(
+          'Resultados: \${results.length}',
+          style: Theme.of(context).textTheme.labelMedium,
+        ),
+      ),
+      const Divider(height: 16),
+    ];
+
+    if (query.isEmpty) {
+      children.add(_buildInfoSection());
+    }
+
+    if (results.isEmpty) {
+      children.add(const Padding(
+        padding: EdgeInsets.all(16),
+        child: Center(child: Text('No se encontraron gastos.')),
+      ));
+    } else {
+      for (final expense in results) {
+        children.add(Padding(
+          padding: const EdgeInsets.fromLTRB(16, 0, 16, 12),
+          child: _buildResultCard(expense),
+        ));
+      }
+    }
+
     return Scaffold(
       appBar: AppBar(
         title: const Text('Guía CFDI'),
       ),
-      body: Column(
-        crossAxisAlignment: CrossAxisAlignment.start,
-        children: [
-          _buildSearchField(),
-          _buildFilterChips(),
-          if (query.isEmpty) _buildInfoSection(),
-          Expanded(
-            child: results.isEmpty
-                ? const Center(child: Text('No se encontraron gastos.'))
-                : ListView.builder(
-                    padding: const EdgeInsets.symmetric(
-                        horizontal: 16, vertical: 8),
-                    itemCount: results.length,
-                    itemBuilder: (context, index) {
-                      final expense = results[index];
-                      return Padding(
-                        padding: const EdgeInsets.only(bottom: 12),
-                        child: _buildResultCard(expense),
-                      );
-                    },
-                  ),
-          ),
-        ],
+      body: ListView(
+        children: children,
       ),
     );
   }
@@ -169,15 +179,20 @@ class _CFDIGuideScreenState extends State<CFDIGuideScreen> {
     final bool deductible = expense['deductible'] as bool;
     final iconColor =
         deductible ? AppTheme.successColor : AppTheme.errorColor;
+    final IconData icon = expense['icon'] as IconData? ?? Icons.receipt_long;
     return ModernCard(
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
         children: [
           Row(
             children: [
-              Icon(
-                deductible ? Icons.check_circle : Icons.cancel,
-                color: iconColor,
+              Container(
+                padding: const EdgeInsets.all(8),
+                decoration: BoxDecoration(
+                  color: AppTheme.primaryColor.withOpacity(0.1),
+                  borderRadius: BorderRadius.circular(8),
+                ),
+                child: Icon(icon, color: AppTheme.primaryColor, size: 20),
               ),
               const SizedBox(width: 8),
               Expanded(
@@ -193,13 +208,23 @@ class _CFDIGuideScreenState extends State<CFDIGuideScreen> {
                   color: iconColor.withOpacity(0.1),
                   borderRadius: BorderRadius.circular(8),
                 ),
-                child: Text(
-                  deductible ? 'Acreditable' : 'No acreditable',
-                  style: TextStyle(
-                    color: iconColor,
-                    fontSize: 12,
-                    fontWeight: FontWeight.bold,
-                  ),
+                child: Row(
+                  children: [
+                    Icon(
+                      deductible ? Icons.check_circle : Icons.cancel,
+                      color: iconColor,
+                      size: 16,
+                    ),
+                    const SizedBox(width: 4),
+                    Text(
+                      deductible ? 'Acreditable' : 'No acreditable',
+                      style: TextStyle(
+                        color: iconColor,
+                        fontSize: 12,
+                        fontWeight: FontWeight.bold,
+                      ),
+                    ),
+                  ],
                 ),
               ),
             ],


### PR DESCRIPTION
## Summary
- extend `resico_deductibles.dart` with many more deductible examples and add icons
- show result count and divider in CFDI guide screen
- show an icon for each expense item and style the status label
- make entire CFDI guide scrollable

## Testing
- `dart format lib test` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a0eb7dca88322af7d31d3a1f6cff9