### PR TITLE
Add SAT debt transactions

### DIFF
--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -141,4 +141,5 @@ enum TransactionType {
   income,
   expense,
   transfer,
+  satDebt,
 }

--- a/lib/providers/finance_provider.dart
+++ b/lib/providers/finance_provider.dart
@@ -162,7 +162,8 @@ class FinanceProvider extends ChangeNotifier {
     double newBalance = account.balance;
     if (type == TransactionType.income) {
       newBalance += amount;
-    } else if (type == TransactionType.expense) {
+    } else if (type == TransactionType.expense ||
+        type == TransactionType.satDebt) {
       newBalance -= amount;
     }
 
@@ -236,7 +237,8 @@ class FinanceProvider extends ChangeNotifier {
     
     if (transaction.type == TransactionType.income) {
       newBalance -= transaction.amount; // Revertir ingreso
-    } else if (transaction.type == TransactionType.expense) {
+    } else if (transaction.type == TransactionType.expense ||
+        transaction.type == TransactionType.satDebt) {
       newBalance += transaction.amount; // Revertir gasto
     }
     
@@ -272,14 +274,16 @@ class FinanceProvider extends ChangeNotifier {
     double newBalance = account.balance;
     if (oldTransaction.type == TransactionType.income) {
       newBalance -= oldTransaction.amount;
-    } else if (oldTransaction.type == TransactionType.expense) {
+    } else if (oldTransaction.type == TransactionType.expense ||
+        oldTransaction.type == TransactionType.satDebt) {
       newBalance += oldTransaction.amount;
     }
     
     // Aplicar el nuevo cambio
     if (type == TransactionType.income) {
       newBalance += amount;
-    } else if (type == TransactionType.expense) {
+    } else if (type == TransactionType.expense ||
+        type == TransactionType.satDebt) {
       newBalance -= amount;
     }
     
@@ -421,19 +425,22 @@ class FinanceProvider extends ChangeNotifier {
       if (transaction.source == MoneySource.personal) {
         if (transaction.type == TransactionType.income) {
           personalBalance += transaction.amount;
-        } else if (transaction.type == TransactionType.expense) {
+        } else if (transaction.type == TransactionType.expense ||
+            transaction.type == TransactionType.satDebt) {
           personalBalance -= transaction.amount;
         }
       } else if (transaction.source == MoneySource.work) {
         if (transaction.type == TransactionType.income) {
           workBalance += transaction.amount;
-        } else if (transaction.type == TransactionType.expense) {
+        } else if (transaction.type == TransactionType.expense ||
+            transaction.type == TransactionType.satDebt) {
           workBalance -= transaction.amount;
         }
       } else if (transaction.source == MoneySource.family) {
         if (transaction.type == TransactionType.income) {
           familyBalance += transaction.amount;
-        } else if (transaction.type == TransactionType.expense) {
+        } else if (transaction.type == TransactionType.expense ||
+            transaction.type == TransactionType.satDebt) {
           familyBalance -= transaction.amount;
         }
       }

--- a/lib/providers/transaction_provider.dart
+++ b/lib/providers/transaction_provider.dart
@@ -18,7 +18,9 @@ class TransactionProvider extends ChangeNotifier {
 
   double get totalExpenses {
     return _transactions
-        .where((t) => t.type == TransactionType.expense)
+        .where((t) =>
+            t.type == TransactionType.expense ||
+            t.type == TransactionType.satDebt)
         .fold(0, (sum, t) => sum + t.totalAmount);
   }
 
@@ -94,9 +96,12 @@ class TransactionProvider extends ChangeNotifier {
     final Map<String, double> categoryTotals = {};
     
     for (final transaction in _transactions) {
-      if (transaction.type == TransactionType.expense && transaction.category != null) {
-        categoryTotals[transaction.category!] = 
-            (categoryTotals[transaction.category!] ?? 0) + transaction.totalAmount;
+      if ((transaction.type == TransactionType.expense ||
+              transaction.type == TransactionType.satDebt) &&
+          transaction.category != null) {
+        categoryTotals[transaction.category!] =
+            (categoryTotals[transaction.category!] ?? 0) +
+                transaction.totalAmount;
       }
     }
     

--- a/lib/screens/edit_transaction_screen.dart
+++ b/lib/screens/edit_transaction_screen.dart
@@ -97,6 +97,37 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
       curve: Curves.easeInOut,
     );
     _animationController.forward();
+  } 
+
+  Widget _buildSatDebtDropdown() {
+    return DropdownButtonFormField<SatDebtType>(
+      value: _satDebtType,
+      decoration: const InputDecoration(
+        labelText: 'Tipo de Deuda SAT',
+      ),
+      items: const [
+        DropdownMenuItem(
+          value: SatDebtType.iva,
+          child: Text('IVA'),
+        ),
+        DropdownMenuItem(
+          value: SatDebtType.isr,
+          child: Text('ISR'),
+        ),
+      ],
+      onChanged: (value) {
+        setState(() {
+          _satDebtType = value ?? SatDebtType.none;
+        });
+      },
+      validator: (value) {
+        if (_selectedType == TransactionType.satDebt &&
+            (value == null || value == SatDebtType.none)) {
+          return 'Selecciona el tipo de deuda';
+        }
+        return null;
+      },
+    );
   }
 
   @override
@@ -392,28 +423,11 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
             ),
             if (_selectedCategory == 'Deuda SAT') ...[
               const SizedBox(height: 16),
-              DropdownButtonFormField<SatDebtType>(
-                value: _satDebtType,
-                decoration: const InputDecoration(
-                  labelText: 'Tipo de Deuda SAT',
-                ),
-                items: const [
-                  DropdownMenuItem(
-                    value: SatDebtType.iva,
-                    child: Text('IVA'),
-                  ),
-                  DropdownMenuItem(
-                    value: SatDebtType.isr,
-                    child: Text('ISR'),
-                  ),
-                ],
-                onChanged: (value) {
-                  setState(() {
-                    _satDebtType = value ?? SatDebtType.none;
-                  });
-                },
-              ),
+              _buildSatDebtDropdown(),
             ],
+            const SizedBox(height: 16),
+          ] else if (_selectedType == TransactionType.satDebt) ...[
+            _buildSatDebtDropdown(),
             const SizedBox(height: 16),
           ],
           InkWell(
@@ -539,6 +553,16 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
 
   void _saveTransaction() async {
     if (_formKey.currentState!.validate()) {
+      if (_selectedType == TransactionType.satDebt &&
+          _satDebtType == SatDebtType.none) {
+        ScaffoldMessenger.of(context).showSnackBar(
+          const SnackBar(
+            content: Text('Selecciona si la deuda es de IVA o ISR'),
+            backgroundColor: Colors.red,
+          ),
+        );
+        return;
+      }
       setState(() {
         _isLoading = true;
       });

--- a/lib/screens/modern_dashboard_screen.dart
+++ b/lib/screens/modern_dashboard_screen.dart
@@ -749,14 +749,20 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
                               leading: CircleAvatar(
                                 backgroundColor: transaction.type == TransactionType.income
                                     ? AppTheme.successColor.withOpacity(0.1)
-                                    : AppTheme.errorColor.withOpacity(0.1),
+                                    : transaction.type == TransactionType.satDebt
+                                        ? AppTheme.warningColor.withOpacity(0.1)
+                                        : AppTheme.errorColor.withOpacity(0.1),
                                 child: Icon(
                                   transaction.type == TransactionType.income
                                       ? Icons.arrow_downward
-                                      : Icons.arrow_upward,
+                                      : transaction.type == TransactionType.satDebt
+                                          ? Icons.gavel
+                                          : Icons.arrow_upward,
                                   color: transaction.type == TransactionType.income
                                       ? AppTheme.successColor
-                                      : AppTheme.errorColor,
+                                      : transaction.type == TransactionType.satDebt
+                                          ? AppTheme.warningColor
+                                          : AppTheme.errorColor,
                                   size: 20,
                                 ),
                               ),
@@ -779,13 +785,14 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
                                 crossAxisAlignment: CrossAxisAlignment.end,
                                 children: [
                                   Text(
-                                    '${transaction.type == TransactionType.expense ? '-' : '+'}'
-                                    '${currencyFormat.format(transaction.amount)}',
+                                    '${transaction.type == TransactionType.income ? '+' : '-'}${currencyFormat.format(transaction.amount)}',
                                     style: TextStyle(
                                       fontWeight: FontWeight.bold,
                                       color: transaction.type == TransactionType.income
                                           ? AppTheme.successColor
-                                          : AppTheme.errorColor,
+                                          : transaction.type == TransactionType.satDebt
+                                              ? AppTheme.warningColor
+                                              : AppTheme.errorColor,
                                     ),
                                   ),
                                   if (transaction.category != null)

--- a/lib/screens/transactions_screen.dart
+++ b/lib/screens/transactions_screen.dart
@@ -76,6 +76,10 @@ class _TransactionsScreenState extends State<TransactionsScreen>
                     _filterType = TransactionType.expense;
                     _showOnlyDeductible = false;
                     break;
+                  case 'satDebt':
+                    _filterType = TransactionType.satDebt;
+                    _showOnlyDeductible = false;
+                    break;
                   case 'deductible':
                     _filterType = null;
                     _showOnlyDeductible = true;
@@ -111,6 +115,16 @@ class _TransactionsScreenState extends State<TransactionsScreen>
                     Icon(Icons.arrow_upward, color: AppTheme.errorColor, size: 20),
                     SizedBox(width: 8),
                     Text('Gastos'),
+                  ],
+                ),
+              ),
+              const PopupMenuItem(
+                value: 'satDebt',
+                child: Row(
+                  children: [
+                    Icon(Icons.gavel, color: AppTheme.warningColor, size: 20),
+                    SizedBox(width: 8),
+                    Text('Deuda SAT'),
                   ],
                 ),
               ),
@@ -523,6 +537,9 @@ class _TransactionsScreenState extends State<TransactionsScreen>
     } else if (_filterType == TransactionType.expense) {
       message = 'No hay gastos';
       subtitle = 'Los gastos aparecerán aquí';
+    } else if (_filterType == TransactionType.satDebt) {
+      message = 'No hay deudas SAT';
+      subtitle = 'Las deudas SAT aparecerán aquí';
     } else if (_showOnlyDeductible) {
       message = 'No hay gastos deducibles';
       subtitle = 'Los gastos con IVA acreditable aparecerán aquí';
@@ -567,6 +584,8 @@ class _TransactionsScreenState extends State<TransactionsScreen>
         return AppTheme.errorColor;
       case TransactionType.transfer:
         return AppTheme.infoColor;
+      case TransactionType.satDebt:
+        return AppTheme.warningColor;
     }
   }
 
@@ -578,6 +597,8 @@ class _TransactionsScreenState extends State<TransactionsScreen>
         return Icons.arrow_upward;
       case TransactionType.transfer:
         return Icons.swap_horiz;
+      case TransactionType.satDebt:
+        return Icons.gavel;
     }
   }
 


### PR DESCRIPTION
## Summary
- extend `TransactionType` with `satDebt`
- handle new type in finance and transaction providers
- support SAT debt in creation, editing, and listings

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a5fc917948322837611884db047ad