### PR TITLE
Fix SAT debt dropdown

### DIFF
--- a/lib/screens/compatible_transaction_screen.dart
+++ b/lib/screens/compatible_transaction_screen.dart
@@ -663,7 +663,7 @@ class _CompatibleTransactionScreenState extends State<CompatibleTransactionScree
 
   Widget _buildSatDebtDropdown() {
     return DropdownButtonFormField<SatDebtType>(
-      value: _satDebtType,
+      value: _satDebtType == SatDebtType.none ? null : _satDebtType,
       decoration: InputDecoration(
         filled: true,
         fillColor: Colors.grey[100],

--- a/lib/screens/edit_transaction_screen.dart
+++ b/lib/screens/edit_transaction_screen.dart
@@ -101,7 +101,7 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
 
   Widget _buildSatDebtDropdown() {
     return DropdownButtonFormField<SatDebtType>(
-      value: _satDebtType,
+      value: _satDebtType == SatDebtType.none ? null : _satDebtType,
       decoration: const InputDecoration(
         labelText: 'Tipo de Deuda SAT',
       ),


### PR DESCRIPTION
## Summary
- fix dropdown initialization for SAT debt selection so the form loads without assertion errors

## Testing
- `apt-get update` *(fails: mise.jdx.dev blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687a63a22b8c8322b1fd50091911c32c