### PR TITLE
Add SAT debt payment handling and update dashboard

### DIFF
--- a/lib/providers/finance_provider.dart
+++ b/lib/providers/finance_provider.dart
@@ -79,13 +79,18 @@ class FinanceProvider extends ChangeNotifier {
     }
     
     // Agregar deudas de tarjetas de crédito
-    double totalCreditCardDebt = _creditCards.fold(0, (sum, card) => sum + card.currentBalance);
+    double totalCreditCardDebt =
+        _creditCards.fold(0, (sum, card) => sum + card.currentBalance);
     double totalDebt = totalCreditDebt + totalCreditCardDebt;
-    
+
+    // Deudas con Hacienda
+    double satDebt = getSatDebtSummary()['total'];
+
     _totalBalances = {
       'totalInAccounts': totalInAccounts,
       'totalDebt': totalDebt,
-      'netWorth': totalInAccounts - totalDebt,
+      'satDebt': satDebt,
+      'netWorth': totalInAccounts - totalDebt - satDebt,
     };
     notifyListeners();
   }

--- a/lib/screens/dashboard_screen.dart
+++ b/lib/screens/dashboard_screen.dart
@@ -130,12 +130,27 @@ class _DashboardScreenState extends State<DashboardScreen> {
                 ),
               ],
             ),
+            const SizedBox(height: 8),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceBetween,
+              children: [
+                const Text('Deuda SAT:'),
+                Text(
+                  currencyFormat.format(balances['satDebt'] ?? 0),
+                  style: const TextStyle(
+                    fontSize: 16,
+                    fontWeight: FontWeight.bold,
+                    color: Colors.orange,
+                  ),
+                ),
+              ],
+            ),
             const Divider(height: 24),
             Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
                 const Text(
-                  'Patrimonio neto:',
+                  'Dinero disponible:',
                   style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
                 ),
                 Text(


### PR DESCRIPTION
## Summary
- extend balance calculations with SAT debt tracking
- display SAT debt and available money on dashboard
- make transaction type selection responsive
- allow selecting SAT debt to pay and auto-fill amount
- handle ECOCE income and debt payments when saving transactions

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b0ee8c8148322b4dae9099ecc7a10