### PR TITLE
Fix nullable map lookup in FinanceProvider

### DIFF
--- a/lib/providers/finance_provider.dart
+++ b/lib/providers/finance_provider.dart
@@ -84,7 +84,7 @@ class FinanceProvider extends ChangeNotifier {
     double totalDebt = totalCreditDebt + totalCreditCardDebt;
 
     // Deudas con Hacienda
-    double satDebt = getSatDebtSummary()['total'];
+    double satDebt = getSatDebtSummary()['total'] ?? 0;
 
     _totalBalances = {
       'totalInAccounts': totalInAccounts,


### PR DESCRIPTION
## Summary
- handle possible null return from `getSatDebtSummary()` map lookup

## Testing
- `flutter test` *(fails: Dart SDK version solving failed)*

------
https://chatgpt.com/codex/tasks/task_e_687b1384bc7c832287ccaa4a3c7e1d5f