### PR TITLE
Add automatic SAT debt tracking

### DIFF
--- a/lib/models/transaction.dart
+++ b/lib/models/transaction.dart
@@ -141,5 +141,4 @@ enum TransactionType {
   income,
   expense,
   transfer,
-  satDebt,
 }

--- a/lib/providers/transaction_provider.dart
+++ b/lib/providers/transaction_provider.dart
@@ -18,9 +18,7 @@ class TransactionProvider extends ChangeNotifier {
 
   double get totalExpenses {
     return _transactions
-        .where((t) =>
-            t.type == TransactionType.expense ||
-            t.type == TransactionType.satDebt)
+        .where((t) => t.type == TransactionType.expense)
         .fold(0, (sum, t) => sum + t.totalAmount);
   }
 
@@ -96,8 +94,7 @@ class TransactionProvider extends ChangeNotifier {
     final Map<String, double> categoryTotals = {};
     
     for (final transaction in _transactions) {
-      if ((transaction.type == TransactionType.expense ||
-              transaction.type == TransactionType.satDebt) &&
+      if (transaction.type == TransactionType.expense &&
           transaction.category != null) {
         categoryTotals[transaction.category!] =
             (categoryTotals[transaction.category!] ?? 0) +

--- a/lib/screens/edit_transaction_screen.dart
+++ b/lib/screens/edit_transaction_screen.dart
@@ -46,7 +46,6 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
     'Salud',
     'Educación',
     'Compras',
-    'Deuda SAT',
     'Otros',
   ];
 
@@ -121,8 +120,7 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
         });
       },
       validator: (value) {
-        if (_selectedType == TransactionType.satDebt &&
-            (value == null || value == SatDebtType.none)) {
+        if (value == null || value == SatDebtType.none) {
           return 'Selecciona el tipo de deuda';
         }
         return null;
@@ -415,19 +413,9 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
               onChanged: (value) {
                 setState(() {
                   _selectedCategory = value;
-                  if (value != 'Deuda SAT') {
-                    _satDebtType = SatDebtType.none;
-                  }
                 });
               },
             ),
-            if (_selectedCategory == 'Deuda SAT') ...[
-              const SizedBox(height: 16),
-              _buildSatDebtDropdown(),
-            ],
-            const SizedBox(height: 16),
-          ] else if (_selectedType == TransactionType.satDebt) ...[
-            _buildSatDebtDropdown(),
             const SizedBox(height: 16),
           ],
           InkWell(
@@ -553,16 +541,6 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
 
   void _saveTransaction() async {
     if (_formKey.currentState!.validate()) {
-      if (_selectedType == TransactionType.satDebt &&
-          _satDebtType == SatDebtType.none) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          const SnackBar(
-            content: Text('Selecciona si la deuda es de IVA o ISR'),
-            backgroundColor: Colors.red,
-          ),
-        );
-        return;
-      }
       setState(() {
         _isLoading = true;
       });
@@ -577,7 +555,6 @@ class _EditTransactionScreenState extends State<EditTransactionScreen>
           isDeductibleIva: _isDeductibleIva,
           type: _selectedType,
           source: widget.transaction.source,
-          satDebtType: _satDebtType,
           category: _selectedCategory,
           usoCFDI: _selectedUsoCFDI,
           transactionDate: _selectedDate,

--- a/lib/screens/modern_dashboard_screen.dart
+++ b/lib/screens/modern_dashboard_screen.dart
@@ -187,6 +187,47 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
                     isDebt: true,
                   ),
                 ),
+                const SizedBox(width: 16),
+                Expanded(
+                  child: GestureDetector(
+                    onTap: () async {
+                      final controller = TextEditingController(
+                          text: provider.satDebt.toStringAsFixed(2));
+                      final newVal = await showDialog<double>(
+                        context: context,
+                        builder: (context) => AlertDialog(
+                          title: const Text('Editar deuda SAT'),
+                          content: TextField(
+                            controller: controller,
+                            keyboardType:
+                                const TextInputType.numberWithOptions(decimal: true),
+                            decoration: const InputDecoration(labelText: 'Monto'),
+                          ),
+                          actions: [
+                            TextButton(
+                              onPressed: () => Navigator.pop(context),
+                              child: const Text('Cancelar'),
+                            ),
+                            TextButton(
+                              onPressed: () => Navigator.pop(
+                                  context, double.tryParse(controller.text)),
+                              child: const Text('Guardar'),
+                            ),
+                          ],
+                        ),
+                      );
+                      if (newVal != null) {
+                        await provider.setSatDebt(newVal);
+                      }
+                    },
+                    child: _buildBalanceItem(
+                      'Deuda SAT',
+                      provider.satDebt,
+                      Icons.gavel,
+                      isDebt: true,
+                    ),
+                  ),
+                ),
               ],
             ),
           ],
@@ -749,20 +790,14 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
                               leading: CircleAvatar(
                                 backgroundColor: transaction.type == TransactionType.income
                                     ? AppTheme.successColor.withOpacity(0.1)
-                                    : transaction.type == TransactionType.satDebt
-                                        ? AppTheme.warningColor.withOpacity(0.1)
-                                        : AppTheme.errorColor.withOpacity(0.1),
+                                    : AppTheme.errorColor.withOpacity(0.1),
                                 child: Icon(
                                   transaction.type == TransactionType.income
                                       ? Icons.arrow_downward
-                                      : transaction.type == TransactionType.satDebt
-                                          ? Icons.gavel
-                                          : Icons.arrow_upward,
+                                      : Icons.arrow_upward,
                                   color: transaction.type == TransactionType.income
                                       ? AppTheme.successColor
-                                      : transaction.type == TransactionType.satDebt
-                                          ? AppTheme.warningColor
-                                          : AppTheme.errorColor,
+                                      : AppTheme.errorColor,
                                   size: 20,
                                 ),
                               ),
@@ -788,11 +823,9 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
                                     '${transaction.type == TransactionType.income ? '+' : '-'}${currencyFormat.format(transaction.amount)}',
                                     style: TextStyle(
                                       fontWeight: FontWeight.bold,
-                                      color: transaction.type == TransactionType.income
+                                  color: transaction.type == TransactionType.income
                                           ? AppTheme.successColor
-                                          : transaction.type == TransactionType.satDebt
-                                              ? AppTheme.warningColor
-                                              : AppTheme.errorColor,
+                                          : AppTheme.errorColor,
                                     ),
                                   ),
                                   if (transaction.category != null)

--- a/lib/screens/transactions_screen.dart
+++ b/lib/screens/transactions_screen.dart
@@ -76,10 +76,6 @@ class _TransactionsScreenState extends State<TransactionsScreen>
                     _filterType = TransactionType.expense;
                     _showOnlyDeductible = false;
                     break;
-                  case 'satDebt':
-                    _filterType = TransactionType.satDebt;
-                    _showOnlyDeductible = false;
-                    break;
                   case 'deductible':
                     _filterType = null;
                     _showOnlyDeductible = true;
@@ -115,16 +111,6 @@ class _TransactionsScreenState extends State<TransactionsScreen>
                     Icon(Icons.arrow_upward, color: AppTheme.errorColor, size: 20),
                     SizedBox(width: 8),
                     Text('Gastos'),
-                  ],
-                ),
-              ),
-              const PopupMenuItem(
-                value: 'satDebt',
-                child: Row(
-                  children: [
-                    Icon(Icons.gavel, color: AppTheme.warningColor, size: 20),
-                    SizedBox(width: 8),
-                    Text('Deuda SAT'),
                   ],
                 ),
               ),
@@ -537,9 +523,6 @@ class _TransactionsScreenState extends State<TransactionsScreen>
     } else if (_filterType == TransactionType.expense) {
       message = 'No hay gastos';
       subtitle = 'Los gastos aparecerán aquí';
-    } else if (_filterType == TransactionType.satDebt) {
-      message = 'No hay deudas SAT';
-      subtitle = 'Las deudas SAT aparecerán aquí';
     } else if (_showOnlyDeductible) {
       message = 'No hay gastos deducibles';
       subtitle = 'Los gastos con IVA acreditable aparecerán aquí';
@@ -584,8 +567,6 @@ class _TransactionsScreenState extends State<TransactionsScreen>
         return AppTheme.errorColor;
       case TransactionType.transfer:
         return AppTheme.infoColor;
-      case TransactionType.satDebt:
-        return AppTheme.warningColor;
     }
   }
 
@@ -597,8 +578,6 @@ class _TransactionsScreenState extends State<TransactionsScreen>
         return Icons.arrow_upward;
       case TransactionType.transfer:
         return Icons.swap_horiz;
-      case TransactionType.satDebt:
-        return Icons.gavel;
     }
   }
 

--- a/lib/services/firebase_service.dart
+++ b/lib/services/firebase_service.dart
@@ -619,6 +619,36 @@ class FirebaseService {
       // ignore
     }
   }
+
+  Future<double> getSatDebt() async {
+    try {
+      final doc = await _firestore
+          .collection(_systemMetadataCollection)
+          .doc('sat_debt')
+          .get();
+      if (doc.exists) {
+        final data = doc.data() as Map<String, dynamic>;
+        return (data['amount'] ?? 0).toDouble();
+      }
+      return 0;
+    } catch (e) {
+      return 0;
+    }
+  }
+
+  Future<void> setSatDebt(double amount) async {
+    try {
+      await _firestore
+          .collection(_systemMetadataCollection)
+          .doc('sat_debt')
+          .set({
+            'amount': amount,
+            'updatedAt': DateTime.now().toIso8601String(),
+          }, SetOptions(merge: true));
+    } catch (e) {
+      // ignore
+    }
+  }
   
   // Método para obtener el historial de intereses
   Future<List<DailyInterestRecord>> getInterestHistory(int accountId) async {


### PR DESCRIPTION
## Summary
- track SAT debt in `FinanceProvider`
- persist SAT debt in Firestore via new methods in `FirebaseService`
- show and edit SAT debt on dashboard
- drop SAT debt transaction type and related UI

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687b1e85ab14832282fc3c9bf8a2a9df