### PR TITLE
Improve debt summary

### DIFF
--- a/lib/providers/finance_provider.dart
+++ b/lib/providers/finance_provider.dart
@@ -541,4 +541,31 @@ class FinanceProvider extends ChangeNotifier {
     return accountBalances;
   }
 
+  /// Obtiene un desglose detallado de las deudas actuales.
+  /// - `creditAccounts`: Deuda proveniente de cuentas de tipo crédito
+  ///   (balances negativos).
+  /// - `creditCards`: Deuda total en tarjetas de crédito registradas.
+  /// - `satDebt`: Deuda acumulada con el SAT.
+  /// - `total`: Suma de todas las deudas anteriores.
+  Map<String, double> getDebtBreakdown() {
+    double creditAccountDebt = 0;
+    double creditCardDebt = 0;
+
+    for (final account in _accounts) {
+      if (account.accountType == AccountType.credit && account.balance < 0) {
+        creditAccountDebt += -account.balance;
+      }
+    }
+
+    creditCardDebt =
+        _creditCards.fold(0, (sum, card) => sum + card.currentBalance);
+
+    return {
+      'creditAccounts': creditAccountDebt,
+      'creditCards': creditCardDebt,
+      'satDebt': _satDebt,
+      'total': creditAccountDebt + creditCardDebt + _satDebt,
+    };
+  }
+
 }

--- a/lib/screens/modern_dashboard_screen.dart
+++ b/lib/screens/modern_dashboard_screen.dart
@@ -50,6 +50,8 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
               const SizedBox(height: 16),
               _buildQuickStats(provider),
               const SizedBox(height: 16),
+              _buildDebtBreakdownCard(provider),
+              const SizedBox(height: 16),
               _buildAccountsSection(provider),
               const SizedBox(height: 16),
               _buildCreditCardsSection(provider),
@@ -289,6 +291,50 @@ class _ModernDashboardScreenState extends State<ModernDashboardScreen> {
             ),
           ],
         ),
+      ),
+    );
+  }
+
+  Widget _buildDebtBreakdownCard(FinanceProvider provider) {
+    final debt = provider.getDebtBreakdown();
+
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Desglose de Deuda',
+              style: TextStyle(fontSize: 16, fontWeight: FontWeight.w600),
+            ),
+            const SizedBox(height: 12),
+            _buildDebtRow('Tarjetas de Crédito', debt['creditCards'] ?? 0),
+            _buildDebtRow('Cuentas de Crédito', debt['creditAccounts'] ?? 0),
+            _buildDebtRow('Deuda SAT', debt['satDebt'] ?? 0),
+            const Divider(),
+            _buildDebtRow('Total', debt['total'] ?? 0, isBold: true),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildDebtRow(String label, double amount, {bool isBold = false}) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 2),
+      child: Row(
+        children: [
+          Text(label),
+          const Spacer(),
+          Text(
+            currencyFormat.format(amount),
+            style: TextStyle(
+              fontWeight: isBold ? FontWeight.bold : FontWeight.normal,
+              color: Colors.red,
+            ),
+          ),
+        ],
       ),
     );
   }


### PR DESCRIPTION
## Summary
- add FinanceProvider.getDebtBreakdown helper
- display breakdown card on the dashboard

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b39f124288322b0ae7d9b5a5f5d08